### PR TITLE
Add Aired Order as option

### DIFF
--- a/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.de_de/strings.po
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.de_de/strings.po
@@ -71,3 +71,7 @@ msgstr "Regional"
 msgctxt "#30013"
 msgid "Alternate DVD"
 msgstr "Alternativ DVD"
+
+msgctxt "#30014"
+msgid "Aired Order"
+msgstr "Ausstrahlungsreihenfolge"

--- a/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.en_au/strings.po
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.en_au/strings.po
@@ -71,3 +71,7 @@ msgstr "Regional"
 msgctxt "#30013"
 msgid "Alternate DVD"
 msgstr "Alternate DVD"
+
+msgctxt "#30014"
+msgid "Aired Order"
+msgstr "Aired Order"

--- a/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.en_gb/strings.po
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.en_gb/strings.po
@@ -71,3 +71,7 @@ msgstr "Regional"
 msgctxt "#30013"
 msgid "Alternate DVD"
 msgstr "Alternate DVD"
+
+msgctxt "#30014"
+msgid "Aired Order"
+msgstr "Aired Order"

--- a/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.en_us/strings.po
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.en_us/strings.po
@@ -71,3 +71,7 @@ msgstr "Regional"
 msgctxt "#30013"
 msgid "Alternate DVD"
 msgstr "Alternate DVD"
+
+msgctxt "#30014"
+msgid "Aired Order"
+msgstr "Aired Order"

--- a/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.fr_fr/strings.po
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.fr_fr/strings.po
@@ -71,3 +71,7 @@ msgstr "Régional"
 msgctxt "#30013"
 msgid "Alternate DVD"
 msgstr "Alternatif DVD"
+
+msgctxt "#30014"
+msgid "Aired Order"
+msgstr "Ordre diffusé"

--- a/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.he_IL/strings.po
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.he_IL/strings.po
@@ -71,3 +71,7 @@ msgstr "אֵזוֹרִי"
 msgctxt "#30013"
 msgid "Alternate DVD"
 msgstr "DVD חלופי"
+
+msgctxt "#30014"
+msgid "Aired Order"
+msgstr "סדר משודר"

--- a/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.pt_br/strings.po
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.pt_br/strings.po
@@ -71,3 +71,7 @@ msgstr "Regional"
 msgctxt "#30013"
 msgid "Alternate DVD"
 msgstr "Alternativo DVD"
+
+msgctxt "#30014"
+msgid "Aired Order"
+msgstr "Ordem transmitida"

--- a/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.pt_pt/strings.po
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.pt_pt/strings.po
@@ -71,3 +71,7 @@ msgstr "Regional"
 msgctxt "#30013"
 msgid "Alternate DVD"
 msgstr "Alternativo DVD"
+
+msgctxt "#30014"
+msgid "Aired Order"
+msgstr "Ordem transmitida"

--- a/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.tr_tr/strings.po
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/language/resource.language.tr_tr/strings.po
@@ -71,3 +71,7 @@ msgstr "Bölgesel"
 msgctxt "#30013"
 msgid "Alternate DVD"
 msgstr "Alternatif DVD"
+
+msgctxt "#30014"
+msgid "Aired Order"
+msgstr "Yayınlanan Sipariş"

--- a/metadata.tvshows.thetvdb.com.v4.python/resources/lib/tvdb.py
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/lib/tvdb.py
@@ -28,6 +28,7 @@ class SeasonType(enum.IntEnum):
     ALTERNATE = 4
     REGIONAL = 5
     ALTDVD = 6
+    OFFICIAL = 7
 
 
 class Auth:

--- a/metadata.tvshows.thetvdb.com.v4.python/resources/settings.xml
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/settings.xml
@@ -210,6 +210,7 @@
 						<option label="30005">4</option>
 						<option label="30012">5</option>
 						<option label="30013">6</option>
+						<option label="30014">7</option>
 					</options>
 					</constraints>
 					<control type="list" format="string">


### PR DESCRIPTION
Aired Order is not always the default and cannot be chosen if the default has been changed. This allows choosing the Air Order explicitly