### PR TITLE
Limit Season Posters (due to Kodi 64k art string limit)

### DIFF
--- a/metadata.tvshows.thetvdb.com.v4.python/resources/lib/artwork.py
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/lib/artwork.py
@@ -4,7 +4,7 @@ import xbmcplugin
 from .tvdb import Client, get_artworks_from_show, get_language
 
 MAX_IMAGES_NUMBER = 10
-
+MAX_SEASON_IMAGES_NUMER = 3
 
 def add_artworks(show, liz, language):
     
@@ -15,9 +15,13 @@ def add_artworks(show, liz, language):
     for art_type, images in artworks.items():
         for image in images[:MAX_IMAGES_NUMBER]:
             liz.addAvailableArtwork(image['image'], art_type)
-
+    
+    season_posters_dict = {}
     for image, season_number in season_posters:
-        liz.addAvailableArtwork(image, 'poster', season=season_number)
+        season_posters_dict.setdefault(season_number, []).append(image)
+    for season_number, images in season_posters_dict.items():
+        for image in images[:MAX_SEASON_IMAGES_NUMER]:
+            liz.addAvailableArtwork(image, 'poster', season=season_number)
 
     fanart_items = []
     for fanart in fanarts[:MAX_IMAGES_NUMBER]:


### PR DESCRIPTION
There is a grumbling issue in Kodi in that there is one TEXT string (limited to 64k) that stores a TV show's artwork.

See https://github.com/xbmc/xbmc/issues/15768

This causes Kodi to fail adding the TV show (in a non-specific way when a MarinaDB database is used).

Using the example of the Simpsons the string that is returned by this scraper is about 120kb. The existing scraper code limited most picture types to 10 images but there is no limit on per season posters  - and some seasons return 40+ images.

This PR limits season posters to 3 per season. Using the case of the simpsons the string returned is then 22kb.